### PR TITLE
[Feat-9] 블로그 상세 페이지 라우팅 및 데이터 로딩 구현

### DIFF
--- a/seoya-log/src/app/posts/[category_name]/[post_id]/page.tsx
+++ b/seoya-log/src/app/posts/[category_name]/[post_id]/page.tsx
@@ -1,0 +1,34 @@
+import { getAllPostIds, getPostData } from "@/helper/lib/posts";
+
+interface Props {
+  params: {
+    category_name: string;
+    post_id: string;
+  };
+}
+
+export async function generateStaticParams(): Promise<
+  Array<{ params: { category_name: string; post_id: string } }>
+> {
+  const paths: Props[] = getAllPostIds();
+
+  return paths.map(({ params: { category_name, post_id } }) => ({
+    params: { category_name, post_id },
+  }));
+}
+
+export default async function Post({ params }: Props) {
+  const postData = await getPostData(params.category_name, params.post_id);
+
+  if (!postData) {
+    return <div>Post not found</div>;
+  }
+
+  return (
+    <div>
+      <h1>Category: {postData.category}</h1>
+      <h2>Post ID: {postData.id}</h2>
+      <p>{postData.content}</p>
+    </div>
+  );
+}

--- a/seoya-log/src/app/posts/page.tsx
+++ b/seoya-log/src/app/posts/page.tsx
@@ -1,5 +1,20 @@
-const PostListPage = () => {
-  return <h1>게시물 리스트 페이지 !</h1>;
-};
+// pages/posts/page.tsx
+import Link from "next/link";
+import { dummyPosts } from "@/helper/lib/dummyData"; // 더미 데이터 사용
 
-export default PostListPage;
+export default function PostsPage() {
+  return (
+    <div>
+      <h1>All Posts</h1>
+      <ul>
+        {dummyPosts.map((post) => (
+          <li key={post.id}>
+            <Link href={`/posts/${post.category}/${post.id}`}>
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/seoya-log/src/app/posts/page.tsx
+++ b/seoya-log/src/app/posts/page.tsx
@@ -1,6 +1,5 @@
-// pages/posts/page.tsx
 import Link from "next/link";
-import { dummyPosts } from "@/helper/lib/dummyData"; // 더미 데이터 사용
+import { dummyPosts } from "@/helper/lib/dummyData";
 
 export default function PostsPage() {
   return (

--- a/seoya-log/src/helper/lib/dummyData.js
+++ b/seoya-log/src/helper/lib/dummyData.js
@@ -1,4 +1,3 @@
-// lib/dummyData.js
 export const dummyPosts = [
   {
     category: "javascript",

--- a/seoya-log/src/helper/lib/dummyData.js
+++ b/seoya-log/src/helper/lib/dummyData.js
@@ -1,0 +1,15 @@
+// lib/dummyData.js
+export const dummyPosts = [
+  {
+    category: "javascript",
+    id: "1",
+    title: "JavaScript Basics",
+    content: "This is a post about JavaScript basics.",
+  },
+  {
+    category: "react",
+    id: "2",
+    title: "React Introduction",
+    content: "This is a post about getting started with React.",
+  },
+];

--- a/seoya-log/src/helper/lib/posts.js
+++ b/seoya-log/src/helper/lib/posts.js
@@ -1,0 +1,26 @@
+// lib/posts.js
+import { dummyPosts } from "./dummyData";
+
+export function getAllPostIds() {
+  return dummyPosts.map((post) => ({
+    params: {
+      category_name: post.category,
+      post_id: post.id,
+    },
+  }));
+}
+
+export async function getPostData(category, id) {
+  const post = await dummyPosts.find(
+    (post) => post.category === category && post.id === id
+  );
+
+  if (!post) {
+    console.error(`Post not found for category: ${category}, id: ${id}`); // 오류 로그 추가
+    return null;
+  }
+
+  return {
+    ...post,
+  };
+}

--- a/seoya-log/src/helper/lib/posts.js
+++ b/seoya-log/src/helper/lib/posts.js
@@ -1,4 +1,3 @@
-// lib/posts.js
 import { dummyPosts } from "./dummyData";
 
 export function getAllPostIds() {
@@ -16,7 +15,7 @@ export async function getPostData(category, id) {
   );
 
   if (!post) {
-    console.error(`Post not found for category: ${category}, id: ${id}`); // 오류 로그 추가
+    console.error(`Post not found for category: ${category}, id: ${id}`);
     return null;
   }
 


### PR DESCRIPTION
close #9 
## 작업 내역
- 블로그 리스트 페이지 구현
- 블로그 상세 페이지 구현
- 라우팅 및 데이터 로딩 구현

## 구현 화면
![postlist](https://github.com/user-attachments/assets/29f2076f-18eb-4390-96fc-5bc075ef893b)


## 추후 진행할 작업
- 블로그 리스트 페이지 UI, 블로그 상세 페이지 UI 구현